### PR TITLE
Get "dep" otherwise fails with dep not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 WORKDIR /go/src/scratch/
 
 # This takes forever, so do it early on
+RUN go get -u github.com/golang/dep/cmd/dep
 RUN echo "package main" >> dummy.go
 RUN dep init
 RUN dep ensure -v -add github.com/ThalesIgnite/crypto11


### PR DESCRIPTION
While building docker image got this error:

Step 10/18 : RUN dep init
 ---> Running in 2d7061f5dffa
/bin/sh: 1: dep: not found
The command '/bin/sh -c dep init' returned a non-zero code: 127

This change should fix that.